### PR TITLE
Add #to_json on APIResources

### DIFF
--- a/lib/emailable/resources/api_resource.rb
+++ b/lib/emailable/resources/api_resource.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Emailable
   class APIResource
 
@@ -7,14 +9,22 @@ module Emailable
       end
     end
 
-    def inspect
-      ivars = instance_variables.map do |e|
-        [e.to_s.delete('@'), instance_variable_get(e)]
+    def to_h
+      instance_variables.map do |e|
+        [e.to_s.delete('@').to_sym, instance_variable_get(e)]
       end.to_h
-      fmtted_email = @email ? " #{@email}" : ''
-      "#<#{self.class}:0x#{(object_id << 1).to_s(16)}#{fmtted_email}> JSON: " +
-        JSON.pretty_generate(ivars)
+    end
+    
+    alias_method :to_hash, :to_h
+
+    def to_json
+      JSON.generate(to_h)
     end
 
+    def inspect
+      fmtted_email = @email ? " #{@email}" : ''
+      "#<#{self.class}:0x#{(object_id << 1).to_s(16)}#{fmtted_email}> JSON: " +
+        JSON.pretty_generate(to_h)
+    end
   end
 end

--- a/test/emailable/resources/api_resource_test.rb
+++ b/test/emailable/resources/api_resource_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+module Emailable
+  class BatchTest < Minitest::Test
+    class Example < APIResource
+      attr_accessor :foo, :bar, :baz
+    end
+
+    def setup
+      @e = Example.new(foo: 'abc', bar: 123, baz: true)
+    end
+
+    def test_init
+      assert_equal 'abc', @e.foo
+      assert_equal 123,   @e.bar
+      assert_equal true,  @e.baz
+    end
+
+    def test_to_h
+      correct = {
+        foo: 'abc',
+        bar: 123,
+        baz: true,
+      }
+      assert_equal correct, @e.to_h
+      assert_equal correct, @e.to_hash
+    end
+
+    def test_to_json
+      correct = %q|{"foo":"abc","bar":123,"baz":true}|
+      assert_equal correct, @e.to_json
+    end
+
+    def test_inspect
+      correct = <<~STR.chomp
+        #<> JSON: {
+          "foo": "abc",
+          "bar": 123,
+          "baz": true
+        }
+      STR
+      output = @e.inspect.gsub(/<.*>/, '<>')
+      assert_equal correct, output
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a to_h and to_json method on API resources. It's helpful if you want to get back the raw data that an Emailable API Request returned, for example to serialize and cache that data for future use.